### PR TITLE
Replaced lazy_static by std::sync::OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,5 @@
 version = 3
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "spores"
 version = "0.1.0"
-dependencies = [
- "lazy_static",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,3 @@
 name = "spores"
 version = "0.1.0"
 edition = "2021"
-# why does this have a warning during build??
-# lldb = "0.0.11"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-lazy_static = "1.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn get_sleep(_: &str) -> String {
 
 fn get_carousel(_: &str) -> String {
     let body = CAROUSEL;
-    response(body, "200  Ok")   
+    response(body, "200  Ok")
 }
 
 fn get_index(_: &str) -> String {


### PR DESCRIPTION
With Rust 1.70.0, we now have [OnceLock](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) that can easily replace `lazy_static`